### PR TITLE
Cargo.toml: Require log crate without features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,11 @@ serde = { version=">=1.0", optional = true, features=["derive"] }
 rayon = ">=1.0"
 crossbeam-utils = "0.6.5"
 wyhash = "0.3.0"
+log = "0.4.*"
 
 [dev-dependencies]
 quickcheck = "0.3"
 bencher = ">=0.1"
-
-[dependencies.log]
-version = "0.4"
-features = ["release_max_level_info"]
 
 [dependencies.heapsize]
 optional = true


### PR DESCRIPTION
Hi,

I was rather confused as to why my downstream application code was not logging debug messages in release mode - seems having `features = ["release_max_level_info"]` here was the reason (with the same thing in rust-debruijn). Was the intention here really to set the global maximum logging level?

Thanks, ben