### PR TITLE
Allow HashMap querying using derived keys implementing Borrow<K>

### DIFF
--- a/src/bitvector.rs
+++ b/src/bitvector.rs
@@ -134,7 +134,7 @@ impl BitVector {
         }
 
         BitVector {
-            bits: bits,
+            bits,
             vector: v.into_boxed_slice(),
         }
     }
@@ -153,7 +153,7 @@ impl BitVector {
 
         bvec.push(to_au(usize::max_value() >> (64 - offset)));
         BitVector {
-            bits: bits,
+            bits,
             vector: bvec.into_boxed_slice(),
         }
     }

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -4,6 +4,7 @@
 use serde::{self, Deserialize, Serialize};
 
 use crate::Mphf;
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::ExactSizeIterator;
@@ -49,12 +50,16 @@ where
     }
 
     /// Get the value associated with `key`, if available, otherwise return None
-    pub fn get(&self, kmer: &K) -> Option<&D> {
+    pub fn get<Q: ?Sized>(&self, kmer: &Q) -> Option<&D>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(kmer);
         match maybe_pos {
             Some(pos) => {
                 let hashed_kmer = &self.keys[pos as usize];
-                if *kmer == hashed_kmer.clone() {
+                if kmer == hashed_kmer.borrow() {
                     Some(&self.values[pos as usize])
                 } else {
                     None
@@ -65,12 +70,16 @@ where
     }
 
     /// Get the position in the Mphf of a key, if the key exists.
-    pub fn get_key_id(&self, kmer: &K) -> Option<usize> {
+    pub fn get_key_id<Q: ?Sized>(&self, kmer: &Q) -> Option<usize>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(&kmer);
         match maybe_pos {
             Some(pos) => {
                 let hashed_kmer = &self.keys[pos as usize];
-                if *kmer == hashed_kmer.clone() {
+                if kmer == hashed_kmer.borrow() {
                     Some(pos as usize)
                 } else {
                     None
@@ -248,12 +257,16 @@ where
         Self::create_map(keys, values, aux_values, mphf)
     }
 
-    pub fn get(&self, kmer: &K) -> Option<(&D1, &D2)> {
+    pub fn get<Q: ?Sized>(&self, kmer: &Q) -> Option<(&D1, &D2)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(kmer);
         match maybe_pos {
             Some(pos) => {
                 let hashed_kmer = &self.keys[pos as usize];
-                if *kmer == hashed_kmer.clone() {
+                if kmer == hashed_kmer.borrow() {
                     Some((&self.values[pos as usize], &self.aux_values[pos as usize]))
                 } else {
                     None
@@ -263,12 +276,16 @@ where
         }
     }
 
-    pub fn get_key_id(&self, kmer: &K) -> Option<usize> {
+    pub fn get_key_id<Q: ?Sized>(&self, kmer: &Q) -> Option<usize>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(&kmer);
         match maybe_pos {
             Some(pos) => {
                 let hashed_kmer = &self.keys[pos as usize];
-                if *kmer == hashed_kmer.clone() {
+                if kmer == hashed_kmer.borrow() {
                     Some(pos as usize)
                 } else {
                     None
@@ -354,7 +371,11 @@ where
     }
 
     /// Get the value associated with `key`, if available, otherwise return None
-    pub fn get(&self, kmer: &K) -> Option<&D1> {
+    pub fn get<Q: ?Sized>(&self, kmer: &Q) -> Option<&D1>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(kmer);
         match maybe_pos {
             Some(pos) => Some(&self.values[pos as usize]),
@@ -416,7 +437,11 @@ where
     }
 
     /// Get the value associated with `key`, if available, otherwise return None
-    pub fn get(&self, kmer: &K) -> Option<(&D1, &D2)> {
+    pub fn get<Q: ?Sized>(&self, kmer: &Q) -> Option<(&D1, &D2)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let maybe_pos = self.mphf.try_hash(kmer);
         match maybe_pos {
             Some(pos) => Some((&self.values[pos as usize], &self.aux_values[pos as usize])),

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -24,7 +24,7 @@ where
     K: Clone + Hash + Debug + PartialEq,
     D: Debug,
 {
-    fn create_map(mut keys: Vec<K>, mut data: Vec<D>, mphf: Mphf<K>) -> BoomHashMap<K, D> {
+    fn create_map(mut keys: Vec<K>, mut values: Vec<D>, mphf: Mphf<K>) -> BoomHashMap<K, D> {
         // reorder the keys and values according to the Mphf
         for i in 0..keys.len() {
             loop {
@@ -33,14 +33,10 @@ where
                     break;
                 }
                 keys.swap(i, kmer_slot);
-                data.swap(i, kmer_slot);
+                values.swap(i, kmer_slot);
             }
         }
-        BoomHashMap {
-            mphf: mphf,
-            keys: keys,
-            values: data,
-        }
+        BoomHashMap { mphf, keys, values }
     }
 
     /// Create a new hash map from the parallel array `keys` and `values`
@@ -226,8 +222,8 @@ where
 {
     fn create_map(
         mut keys: Vec<K>,
-        mut data: Vec<D1>,
-        mut aux_data: Vec<D2>,
+        mut values: Vec<D1>,
+        mut aux_values: Vec<D2>,
         mphf: Mphf<K>,
     ) -> BoomHashMap2<K, D1, D2> {
         // reorder the keys and values according to the Mphf
@@ -238,16 +234,16 @@ where
                     break;
                 }
                 keys.swap(i, kmer_slot);
-                data.swap(i, kmer_slot);
-                aux_data.swap(i, kmer_slot);
+                values.swap(i, kmer_slot);
+                aux_values.swap(i, kmer_slot);
             }
         }
 
         BoomHashMap2 {
-            mphf: mphf,
-            keys: keys,
-            values: data,
-            aux_values: aux_data,
+            mphf,
+            keys,
+            values,
+            aux_values,
         }
     }
 
@@ -344,7 +340,7 @@ where
     K: Clone + Hash + Debug + PartialEq + Send + Sync,
     D1: Debug,
 {
-    pub fn new_parallel(mut keys: Vec<K>, mut data: Vec<D1>) -> NoKeyBoomHashMap<K, D1> {
+    pub fn new_parallel(mut keys: Vec<K>, mut values: Vec<D1>) -> NoKeyBoomHashMap<K, D1> {
         let mphf = Mphf::new_parallel(1.7, &keys, None);
         for i in 0..keys.len() {
             loop {
@@ -353,21 +349,15 @@ where
                     break;
                 }
                 keys.swap(i, kmer_slot);
-                data.swap(i, kmer_slot);
+                values.swap(i, kmer_slot);
             }
         }
 
-        NoKeyBoomHashMap {
-            mphf: mphf,
-            values: data,
-        }
+        NoKeyBoomHashMap { mphf, values }
     }
 
-    pub fn new_with_mphf(mphf: Mphf<K>, data: Vec<D1>) -> NoKeyBoomHashMap<K, D1> {
-        NoKeyBoomHashMap {
-            mphf: mphf,
-            values: data,
-        }
+    pub fn new_with_mphf(mphf: Mphf<K>, values: Vec<D1>) -> NoKeyBoomHashMap<K, D1> {
+        NoKeyBoomHashMap { mphf, values }
     }
 
     /// Get the value associated with `key`, if available, otherwise return None
@@ -402,8 +392,8 @@ where
 {
     pub fn new_parallel(
         mut keys: Vec<K>,
-        mut data: Vec<D1>,
-        mut aux_data: Vec<D2>,
+        mut values: Vec<D1>,
+        mut aux_values: Vec<D2>,
     ) -> NoKeyBoomHashMap2<K, D1, D2> {
         let mphf = Mphf::new_parallel(1.7, &keys, None);
         for i in 0..keys.len() {
@@ -413,26 +403,26 @@ where
                     break;
                 }
                 keys.swap(i, kmer_slot);
-                data.swap(i, kmer_slot);
-                aux_data.swap(i, kmer_slot);
+                values.swap(i, kmer_slot);
+                aux_values.swap(i, kmer_slot);
             }
         }
         NoKeyBoomHashMap2 {
-            mphf: mphf,
-            values: data,
-            aux_values: aux_data,
+            mphf,
+            values,
+            aux_values,
         }
     }
 
     pub fn new_with_mphf(
         mphf: Mphf<K>,
-        data: Vec<D1>,
-        aux_data: Vec<D2>,
+        values: Vec<D1>,
+        aux_values: Vec<D2>,
     ) -> NoKeyBoomHashMap2<K, D1, D2> {
         NoKeyBoomHashMap2 {
-            mphf: mphf,
-            values: data,
-            aux_values: aux_data,
+            mphf,
+            values,
+            aux_values,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ impl<'a, T: 'a + Hash + Clone + Debug> Mphf<T> {
         let ranks = Self::compute_ranks(&bitvecs);
         let r = Mphf {
             bitvecs: bitvecs.into_boxed_slice(),
-            ranks: ranks,
+            ranks,
             phantom: PhantomData,
         };
 
@@ -452,13 +452,11 @@ impl<T: Hash + Clone + Debug + Sync + Send> Mphf<T> {
         }
 
         let ranks = Self::compute_ranks(&bitvecs);
-        let r = Mphf {
+        Mphf {
             bitvecs: bitvecs.into_boxed_slice(),
-            ranks: ranks,
+            ranks,
             phantom: PhantomData,
-        };
-
-        r
+        }
     }
 }
 
@@ -484,12 +482,12 @@ where
     N2: Iterator<Item = T> + ExactSizeIterator,
     N1: IntoIterator<Item = T, IntoIter = N2> + Clone,
 {
-    fn new(object: &'a I, num_keys: usize) -> Queue<'a, I, T> {
+    fn new(keys_object: &'a I, num_keys: usize) -> Queue<'a, I, T> {
         Queue {
-            keys_object: object,
-            queue: object.into_iter(),
+            keys_object,
+            queue: keys_object.into_iter(),
 
-            num_keys: num_keys,
+            num_keys,
             last_key_index: 0,
 
             job_id: 0,
@@ -686,13 +684,11 @@ impl<'a, T: 'a + Hash + Clone + Debug + Send + Sync> Mphf<T> {
         }
 
         let ranks = Self::compute_ranks(&bitvecs);
-        let r = Mphf {
+        Mphf {
             bitvecs: bitvecs.into_boxed_slice(),
-            ranks: ranks,
+            ranks,
             phantom: PhantomData,
-        };
-
-        r
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod par_iter;
 use bitvector::*;
 
 use log::error;
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -53,14 +54,14 @@ fn fold(v: u64) -> u32 {
 }
 
 #[inline]
-fn hash_with_seed<T: Hash>(iter: u64, v: &T) -> u64 {
+fn hash_with_seed<T: Hash + ?Sized>(iter: u64, v: &T) -> u64 {
     let mut state = wyhash::WyHash::with_seed(1 << iter + iter);
     v.hash(&mut state);
     state.finish()
 }
 
 #[inline]
-fn hash_with_seed32<T: Hash>(iter: u64, v: &T) -> u32 {
+fn hash_with_seed32<T: Hash + ?Sized>(iter: u64, v: &T) -> u32 {
     fold(hash_with_seed(iter, v))
 }
 
@@ -70,7 +71,7 @@ fn fastmod(hash: u32, n: u32) -> u64 {
 }
 
 #[inline]
-fn hashmod<T: Hash>(iter: u64, v: &T, n: usize) -> u64 {
+fn hashmod<T: Hash + ?Sized>(iter: u64, v: &T, n: usize) -> u64 {
     // when n < 2^32, use the fast alternative to modulo described here:
     // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
     if n < 1 << 32 {
@@ -221,7 +222,7 @@ impl<'a, T: 'a + Hash + Clone + Debug> Mphf<T> {
     }
 }
 
-impl<T: Hash + Clone + Debug> Mphf<T> {
+impl<T: Clone + Hash + Debug> Mphf<T> {
     /// Generate a minimal perfect hash function for the set of `objects`.
     /// `objects` must not contain any duplicate items.
     /// `gamma` controls the tradeoff between the construction-time and run-time speed,
@@ -359,7 +360,11 @@ impl<T: Hash + Clone + Debug> Mphf<T> {
     /// Compute the hash value of `item`. If `item` was not present
     /// in the set of objects used to construct the hash function, the return
     /// value will an arbitrary value Some(x), or None.
-    pub fn try_hash(&self, item: &T) -> Option<u64> {
+    pub fn try_hash<Q>(&self, item: &Q) -> Option<u64>
+    where
+        T: Borrow<Q>,
+        Q: ?Sized + Hash,
+    {
         for i in 0..self.bitvecs.len() {
             let bv = &(self.bitvecs)[i];
             let hash = hashmod(i as u64, item, bv.capacity());


### PR DESCRIPTION
Since the definition of `K: Borrow<Q>` requires the `Hash` implementations
for both to be equivalent, this should be safe (mechanism copied from std).

This also avoids cloning in `get()` and similar methods, which should be a nice benefit for my use cases (I noticed there are no benchmarks for querying).