### PR TITLE
Remove Clone bounds

### DIFF
--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -21,7 +21,7 @@ pub struct BoomHashMap<K: Hash, D> {
 
 impl<K, D> BoomHashMap<K, D>
 where
-    K: Clone + Hash + Debug + PartialEq,
+    K: Hash + Debug + PartialEq,
     D: Debug,
 {
     fn create_map(mut keys: Vec<K>, mut values: Vec<D>, mphf: Mphf<K>) -> BoomHashMap<K, D> {
@@ -113,7 +113,7 @@ where
 
 impl<K, D> BoomHashMap<K, D>
 where
-    K: Clone + Hash + Debug + PartialEq + Send + Sync,
+    K: Hash + Debug + PartialEq + Send + Sync,
     D: Debug,
 {
     /// Create a new hash map from the parallel array `keys` and `values`, using a parallelized method to construct the Mphf.
@@ -220,7 +220,7 @@ impl<'a, K: Hash, D1, D2> IntoIterator for &'a BoomHashMap2<K, D1, D2> {
 
 impl<K, D1, D2> BoomHashMap2<K, D1, D2>
 where
-    K: Clone + Hash + Debug + PartialEq,
+    K: Hash + Debug + PartialEq,
     D1: Debug,
     D2: Debug,
 {
@@ -323,7 +323,7 @@ where
 
 impl<K, D1, D2> BoomHashMap2<K, D1, D2>
 where
-    K: Clone + Hash + Debug + PartialEq + Send + Sync,
+    K: Hash + Debug + PartialEq + Send + Sync,
     D1: Debug,
     D2: Debug,
 {
@@ -345,7 +345,7 @@ pub struct NoKeyBoomHashMap<K, D1> {
 
 impl<K, D1> NoKeyBoomHashMap<K, D1>
 where
-    K: Clone + Hash + Debug + PartialEq + Send + Sync,
+    K: Hash + Debug + PartialEq + Send + Sync,
     D1: Debug,
 {
     pub fn new_parallel(mut keys: Vec<K>, mut values: Vec<D1>) -> NoKeyBoomHashMap<K, D1> {
@@ -394,7 +394,7 @@ pub struct NoKeyBoomHashMap2<K, D1, D2> {
 
 impl<K, D1, D2> NoKeyBoomHashMap2<K, D1, D2>
 where
-    K: Clone + Hash + Debug + PartialEq + Send + Sync,
+    K: Hash + Debug + PartialEq + Send + Sync,
     D1: Debug,
     D2: Debug,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,17 +614,19 @@ impl<'a, T: 'a + Hash + Clone + Debug + Send + Sync> Mphf<T> {
                             let mut node_pos = 0;
                             for index in 0..num_keys {
                                 let key_index = offset + index;
-                                if !global.done_keys.contains(key_index) {
-                                    let key = node.nth(index - node_pos).unwrap();
-                                    node_pos = index + 1;
+                                if global.done_keys.contains(key_index) {
+                                    continue;
+                                }
 
-                                    let idx = hashmod(iter, &key, size as usize) as usize;
-                                    if job_id == 0 {
-                                        find_collisions(idx, &cx);
-                                    } else {
-                                        remove_collisions(idx, &key, key_index, &cx, &global);
-                                    }
-                                } //end-if
+                                let key = node.nth(index - node_pos).unwrap();
+                                node_pos = index + 1;
+
+                                let idx = hashmod(iter, &key, size as usize) as usize;
+                                if job_id == 0 {
+                                    find_collisions(idx, &cx);
+                                } else {
+                                    remove_collisions(idx, &key, key_index, &cx, &global);
+                                }
                             }
 
                             cx.done_keys_count.fetch_add(num_keys, Ordering::SeqCst);


### PR DESCRIPTION
As discussed in #18, this removes the `Clone` bounds for MPHF keys.

This actually refactors quite a bit of code, hopefully making it easier to follow and possibly more performant, too. I recommend reviewing it per commit -- each commit by itself should be fairly straightforward to verify.