### PR TITLE
Avoid overflow during hashing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,4 +839,12 @@ mod tests {
         let items = (0..1000000).map(|x| x * 2);
         assert!(check_mphf(HashSet::from_iter(items)));
     }
+
+    quickcheck! {
+        fn check_hash_large_seed(v: u64) -> bool {
+            hash_with_seed(u64::max_value(), &v);
+            // Returning true because just checking if it doesn't panic
+            true
+        }
+    }
 }


### PR DESCRIPTION
Add overflow-aware ops when working with the faster hashing introduced in https://github.com/10XGenomics/rust-boomphf/commit/493646a590e78985060c03fb53ee62eed008552b#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R76
Currently it overflows when `iter > 31`.

Add a new test to check that results generated with the previous version are still the same.
