### PR TITLE
use u64/AtomicU64 to make 32bit targets work correctly (eg WASM)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boomphf"
-version = "0.5.9"
+version = "0.6.0"
 authors = ["Patrick Marks <pmarks@gmail.com>"]
 repository = "https://github.com/10XGenomics/rust-boomphf"
 homepage = "https://github.com/10XGenomics/rust-boomphf"


### PR DESCRIPTION
fixes #28. Note WASM doesn't currently support the `parallel` feature, because crossbeam scoped thread don't work.