### PR TITLE
Non-serde DMA support on little endian

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - "1.60.0"
-          - "1.65.0"
+          - "1.66.0"
+          - "1.76.0"
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ harness = false
 [features]
 default = ["parallel"]
 parallel = ["rayon", "crossbeam-utils"]
+
+[profile.release]
+lto = true
+debug = 2

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -4,7 +4,7 @@ extern crate bencher;
 
 use bencher::Bencher;
 
-use boomphf::Mphf;
+use boomphf::{ExternallyHashed, Mphf};
 
 fn build1_ser_u64(bench: &mut Bencher) {
     let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
@@ -13,8 +13,43 @@ fn build1_ser_u64(bench: &mut Bencher) {
     });
 }
 
+fn build1_ser_externally_hashed(bench: &mut Bencher) {
+    let items: Vec<ExternallyHashed> = (0..1000000u64)
+        .map(|x| ExternallyHashed(wyhash::wyrng(&mut (x * 2))))
+        .collect();
+    bench.iter(|| {
+        std::hint::black_box(Mphf::new(2.0, &items));
+    });
+}
+
 fn build1_ser_slices(bench: &mut Bencher) {
     let items: Vec<[u8; 8]> = (0..1000000u64).map(|x| (x * 2).to_le_bytes()).collect();
+    bench.iter(|| {
+        std::hint::black_box(Mphf::new(2.0, &items));
+    });
+}
+
+fn build1_ser_long_slices(bench: &mut Bencher) {
+    let items = (0..1000000u64)
+        .map(|x| {
+            let mut long_key = [0u8; 128];
+            long_key[0..8].copy_from_slice(&(x * 2).to_le_bytes());
+            long_key
+        })
+        .collect::<Vec<_>>();
+    bench.iter(|| {
+        std::hint::black_box(Mphf::new(2.0, &items));
+    });
+}
+
+fn build1_ser_long_slices_externally_hashed(bench: &mut Bencher) {
+    let items = (0..1000000u64)
+        .map(|x| {
+            let mut long_key = [0u8; 128];
+            long_key[0..8].copy_from_slice(&(x * 2).to_le_bytes());
+            ExternallyHashed(wyhash::wyhash(&long_key, 0))
+        })
+        .collect::<Vec<_>>();
     bench.iter(|| {
         std::hint::black_box(Mphf::new(2.0, &items));
     });
@@ -38,16 +73,88 @@ fn build1_par_slices(bench: &mut Bencher) {
     });
 }
 
-fn scan1_ser(bench: &mut Bencher) {
+fn scan1_ser_u64(bench: &mut Bencher) {
     let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
     let phf = Mphf::new(2.0, &items);
 
     bench.iter(|| {
-        for i in (0..1000000u64).map(|x| x * 2) {
+        for i in &items {
             std::hint::black_box(phf.hash(&i));
         }
     });
 }
 
-benchmark_group!(benches, build1_ser_u64, build1_ser_slices, build1_par_u64, build1_par_slices, scan1_ser);
+fn scan1_ser_slice(bench: &mut Bencher) {
+    let items: Vec<[u8; 8]> = (0..1000000u64).map(|x| (x * 2).to_le_bytes()).collect();
+    let phf = Mphf::new(2.0, &items);
+
+    bench.iter(|| {
+        for i in &items {
+            std::hint::black_box(phf.hash(i));
+        }
+    });
+}
+
+fn scan1_ser_externally_hashed(bench: &mut Bencher) {
+    let items: Vec<ExternallyHashed> = (0..1000000u64)
+        .map(|x| ExternallyHashed(wyhash::wyrng(&mut (x * 2))))
+        .collect();
+    let phf = Mphf::new(2.0, &items);
+
+    bench.iter(|| {
+        for i in &items {
+            std::hint::black_box(phf.hash(i));
+        }
+    });
+}
+
+fn scan1_ser_long_key(bench: &mut Bencher) {
+    let items = (0..1000000u64)
+        .map(|x| {
+            let mut long_key = [0u8; 128];
+            long_key[0..8].copy_from_slice(&(x * 2).to_le_bytes());
+            long_key
+        })
+        .collect::<Vec<_>>();
+    let phf = Mphf::new(2.0, &items);
+
+    bench.iter(|| {
+        for i in &items {
+            std::hint::black_box(phf.hash(i));
+        }
+    });
+}
+
+fn scan1_ser_long_key_externally_hashed(bench: &mut Bencher) {
+    let items: Vec<ExternallyHashed> = (0..1000000u64)
+        .map(|x| {
+            let mut long_key = [0u8; 128];
+            long_key[0..8].copy_from_slice(&(x * 2).to_le_bytes());
+            ExternallyHashed(wyhash::wyhash(&long_key, 0))
+        })
+        .collect();
+    let phf = Mphf::new(2.0, &items);
+
+    bench.iter(|| {
+        for i in &items {
+            std::hint::black_box(phf.hash(i));
+        }
+    });
+}
+
+benchmark_group!(
+    benches,
+    build1_ser_externally_hashed,
+    build1_ser_u64,
+    build1_ser_slices,
+    build1_ser_long_slices,
+    build1_ser_long_slices_externally_hashed,
+    build1_par_u64,
+    build1_par_slices,
+    scan1_ser_u64,
+    scan1_ser_slice,
+    scan1_ser_externally_hashed,
+    scan1_ser_long_key,
+    scan1_ser_long_key_externally_hashed
+);
 benchmark_main!(benches);

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -6,19 +6,35 @@ use bencher::Bencher;
 
 use boomphf::Mphf;
 
-fn build1_ser(bench: &mut Bencher) {
+fn build1_ser_u64(bench: &mut Bencher) {
+    let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
     bench.iter(|| {
-        let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
-        let _ = Mphf::new(2.0, &items);
+        std::hint::black_box(Mphf::new(2.0, &items));
+    });
+}
+
+fn build1_ser_slices(bench: &mut Bencher) {
+    let items: Vec<[u8; 8]> = (0..1000000u64).map(|x| (x * 2).to_le_bytes()).collect();
+    bench.iter(|| {
+        std::hint::black_box(Mphf::new(2.0, &items));
     });
 }
 
 #[allow(dead_code)]
-fn build1_par(bench: &mut Bencher) {
+fn build1_par_u64(bench: &mut Bencher) {
+    let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
     #[cfg(feature = "parallel")]
     bench.iter(|| {
-        let items: Vec<u64> = (0..1000000u64).map(|x| x * 2).collect();
-        let _ = Mphf::new_parallel(2.0, &items, None);
+        std::hint::black_box(Mphf::new_parallel(2.0, &items, None));
+    });
+}
+
+#[allow(dead_code)]
+fn build1_par_slices(bench: &mut Bencher) {
+    let items: Vec<[u8; 8]> = (0..1000000u64).map(|x| (x * 2).to_le_bytes()).collect();
+    #[cfg(feature = "parallel")]
+    bench.iter(|| {
+        std::hint::black_box(Mphf::new_parallel(2.0, &items, None));
     });
 }
 
@@ -28,10 +44,10 @@ fn scan1_ser(bench: &mut Bencher) {
 
     bench.iter(|| {
         for i in (0..1000000u64).map(|x| x * 2) {
-            phf.hash(&i);
+            std::hint::black_box(phf.hash(&i));
         }
     });
 }
 
-benchmark_group!(benches, build1_ser, build1_par, scan1_ser);
+benchmark_group!(benches, build1_ser_u64, build1_ser_slices, build1_par_u64, build1_par_slices, scan1_ser);
 benchmark_main!(benches);

--- a/src/bitvector.rs
+++ b/src/bitvector.rs
@@ -363,7 +363,7 @@ impl BitVector {
     #[inline]
     pub fn get_word(&self, word: usize) -> u64 {
         #[cfg(feature = "parallel")]
-        return self.vector[word].load(Ordering::Relaxed) as u64;
+        return self.vector[word].load(Ordering::Relaxed);
 
         #[cfg(not(feature = "parallel"))]
         return self.vector[word] as u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,6 @@ fn hash_with_seed<T: Hash + ?Sized>(iter: u64, v: &T) -> u64 {
 }
 
 #[inline]
-fn hash_with_seed32<T: Hash + ?Sized>(iter: u64, v: &T) -> u32 {
-    fold(hash_with_seed(iter, v))
-}
-
-#[inline]
 fn fastmod(hash: u32, n: u32) -> u64 {
     ((hash as u64) * (n as u64)) >> 32
 }
@@ -78,11 +73,10 @@ fn fastmod(hash: u32, n: u32) -> u64 {
 fn hashmod<T: Hash + ?Sized>(iter: u64, v: &T, n: u64) -> u64 {
     // when n < 2^32, use the fast alternative to modulo described here:
     // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+    let h = hash_with_seed(iter, v);
     if n < (1 << 32) {
-        let h = hash_with_seed32(iter, v);
-        fastmod(h, n as u32) as u64
+        fastmod(fold(h), n as u32) as u64
     } else {
-        let h = hash_with_seed(iter, v);
         h % (n as u64)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,16 +52,184 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "serde")]
 use serde::{self, Deserialize, Serialize};
 
-#[inline]
-fn fold(v: u64) -> u32 {
-    ((v & 0xFFFFFFFF) as u32) ^ ((v >> 32) as u32)
+/// fastmod used to construct the seed as 1 << (iters + iters). However, for external hashing
+/// there's a faster path available via lookup tables if we just pass in iters. This method is
+/// to ensure that pre-existing hashes continue to work as before when not using ExternallyHashed.
+#[inline(always)]
+fn default_seed_correction(seed: u64) -> u64 {
+    1 << (seed + seed)
+}
+
+fn default_hash_with_seed<T: Hash>(value: &T, seed: u64) -> u64 {
+    let mut state = wyhash::WyHash::with_seed(1 << (seed + seed));
+    value.hash(&mut state);
+    state.finish()
+}
+
+// This custom trait allows us to fast-path &[u8] to avoid constructing the temporary Hasher object.
+// Can be simplified once specialization is stabilized.
+pub trait SeedableHash {
+    fn hash_with_seed(&self, seed: u64) -> u64;
+}
+
+impl SeedableHash for [u8] {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(self, default_seed_correction(seed))
+    }
+}
+
+impl<const N: usize> SeedableHash for [u8; N] {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(self, default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for u8 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&[*self], default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for i16 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for u16 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for i32 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for u32 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for i64 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for u64 {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for isize {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl SeedableHash for usize {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        wyhash::wyhash(&self.to_le_bytes(), default_seed_correction(seed))
+    }
+}
+
+impl<T: SeedableHash> SeedableHash for &T {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        (**self).hash_with_seed(seed)
+    }
+}
+
+impl<T: Hash> SeedableHash for &[T] {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        default_hash_with_seed(self, seed)
+    }
+}
+
+impl<T: Hash> SeedableHash for Vec<T> {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        default_hash_with_seed(self, seed)
+    }
+}
+
+impl SeedableHash for &str {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        default_hash_with_seed(self, seed)
+    }
+}
+
+impl SeedableHash for String {
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        default_hash_with_seed(self, seed)
+    }
+}
+
+/// This is a fast-path where the hash for an entry is known externally. That way we can skip hashing the
+/// key for building / lookups which provides savings as keys grow longer or you need to do a lookup of the
+/// same key across multiple perfect hashes. It's the user's responsibility to construct this with a value
+/// that is deterministically derived from a key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExternallyHashed(pub u64);
+
+impl ExternallyHashed {
+    // Helper function for wyrng.
+    const fn wymum(a: u64, b: u64) -> u64 {
+        let mul = a as u128 * b as u128;
+        ((mul >> 64) ^ mul) as u64
+    }
+
+    // wyrng except a constified version
+    const fn wyrng(seed: u64) -> u64 {
+        const P0: u64 = 0xa076_1d64_78bd_642f;
+        const P1: u64 = 0xe703_7ed1_a0b4_28db;
+
+        let seed = seed.wrapping_add(P0);
+        Self::wymum(seed ^ P1, seed)
+    }
+
+    // Generate lookup tables to map the hash seed to a random value.
+    const fn gen_seed_lookups() -> [u64; MAX_ITERS as usize + 1] {
+        let mut result = [0; MAX_ITERS as usize + 1];
+        let mut i = 0;
+        while i <= MAX_ITERS {
+            result[i as usize] = Self::wyrng(i);
+            i += 1;
+        }
+        result
+    }
+    const SEED_HASH_LOOKUP_TABLES: [u64; MAX_ITERS as usize + 1] = Self::gen_seed_lookups();
+
+    // Helper utility to convert the seed passed in from hashmod (which is in 0..MAX_ITERS) into a hash.
+    fn fast_seed_hash(x: u64) -> u64 {
+        debug_assert!(x <= MAX_ITERS);
+        Self::SEED_HASH_LOOKUP_TABLES[x as usize]
+    }
+
+    // Quickly combine two hashes. Because .0 represents a hash, we know it's random and doesn't need to be
+    // independently hashed again, so we just need to combine it uniquely with iters.
+    fn hash_combine(h1: u64, h2: u64) -> u64 {
+        // https://stackoverflow.com/questions/5889238/why-is-xor-the-default-way-to-combine-hashes
+        h1 ^ (h2
+            .wrapping_add(0x517cc1b727220a95)
+            .wrapping_add(h1 << 6)
+            .wrapping_add(h1 >> 2))
+    }
+}
+
+impl SeedableHash for ExternallyHashed {
+    #[inline(always)]
+    fn hash_with_seed(&self, seed: u64) -> u64 {
+        Self::hash_combine(self.0, Self::fast_seed_hash(seed))
+    }
 }
 
 #[inline]
-fn hash_with_seed<T: Hash + ?Sized>(iter: u64, v: &T) -> u64 {
-    let mut state = wyhash::WyHash::with_seed(1 << (iter + iter));
-    v.hash(&mut state);
-    state.finish()
+fn fold(v: u64) -> u32 {
+    ((v & 0xFFFFFFFF) as u32) ^ ((v >> 32) as u32)
 }
 
 #[inline]
@@ -70,14 +238,14 @@ fn fastmod(hash: u32, n: u32) -> u64 {
 }
 
 #[inline]
-fn hashmod<T: Hash + ?Sized>(iter: u64, v: &T, n: u64) -> u64 {
+fn hashmod<T: SeedableHash + ?Sized>(iter: u64, v: &T, n: u64) -> u64 {
     // when n < 2^32, use the fast alternative to modulo described here:
     // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-    let h = hash_with_seed(iter, v);
+    let h = v.hash_with_seed(iter);
     if n < (1 << 32) {
         fastmod(fold(h), n as u32) as u64
     } else {
-        h % (n as u64)
+        h % n
     }
 }
 
@@ -91,7 +259,52 @@ pub struct Mphf<T> {
 
 const MAX_ITERS: u64 = 100;
 
-impl<'a, T: 'a + Hash + Debug> Mphf<T> {
+impl<T> Mphf<T> {
+    fn compute_ranks(bvs: Vec<BitVector>) -> Box<[(BitVector, Box<[u64]>)]> {
+        let mut ranks = Vec::new();
+        let mut pop = 0_u64;
+
+        for bv in bvs {
+            let mut rank: Vec<u64> = Vec::new();
+            for i in 0..bv.num_words() {
+                let v = bv.get_word(i);
+
+                if i % 8 == 0 {
+                    rank.push(pop)
+                }
+
+                pop += v.count_ones() as u64;
+            }
+
+            ranks.push((bv, rank.into_boxed_slice()))
+        }
+
+        ranks.into_boxed_slice()
+    }
+
+    #[inline]
+    fn get_rank(&self, hash: u64, i: usize) -> u64 {
+        let idx = hash as usize;
+        let (bv, ranks) = self.bitvecs.get(i).expect("that level doesn't exist");
+
+        // Last pre-computed rank
+        let mut rank = ranks[idx / 512];
+
+        // Add rank of intervening words
+        for j in (idx / 64) & !7..idx / 64 {
+            rank += bv.get_word(j).count_ones() as u64;
+        }
+
+        // Add rank of final word up to hash
+        let final_word = bv.get_word(idx / 64);
+        if idx % 64 > 0 {
+            rank += (final_word << (64 - (idx % 64))).count_ones() as u64;
+        }
+        rank
+    }
+}
+
+impl<'a, T: 'a + SeedableHash + Debug> Mphf<T> {
     /// Constructs an MPHF from a (possibly lazy) iterator over iterators.
     /// This allows construction of very large MPHFs without holding all the keys
     /// in memory simultaneously.
@@ -121,7 +334,7 @@ impl<'a, T: 'a + Hash + Debug> Mphf<T> {
         loop {
             if iter > MAX_ITERS {
                 error!("ran out of key space. items: {:?}", done_keys.len());
-                panic!("counldn't find unique hashes");
+                panic!("couldn't find unique hashes");
             }
 
             let keys_remaining = if iter == 0 {
@@ -193,7 +406,7 @@ impl<'a, T: 'a + Hash + Debug> Mphf<T> {
 
                         object_pos = object_index + 1;
 
-                        let idx = hashmod(seed, &key, size);
+                        let idx = hashmod(seed, &&key, size);
 
                         if collide.contains(idx) {
                             a.remove(idx);
@@ -220,7 +433,7 @@ impl<'a, T: 'a + Hash + Debug> Mphf<T> {
     }
 }
 
-impl<T: Hash + Debug> Mphf<T> {
+impl<T: SeedableHash + Debug> Mphf<T> {
     /// Generate a minimal perfect hash function for the set of `objects`.
     /// `objects` must not contain any duplicate items.
     /// `gamma` controls the tradeoff between the construction-time and run-time speed,
@@ -268,49 +481,6 @@ impl<T: Hash + Debug> Mphf<T> {
         }
     }
 
-    fn compute_ranks(bvs: Vec<BitVector>) -> Box<[(BitVector, Box<[u64]>)]> {
-        let mut ranks = Vec::new();
-        let mut pop = 0_u64;
-
-        for bv in bvs {
-            let mut rank: Vec<u64> = Vec::new();
-            for i in 0..bv.num_words() {
-                let v = bv.get_word(i);
-
-                if i % 8 == 0 {
-                    rank.push(pop)
-                }
-
-                pop += v.count_ones() as u64;
-            }
-
-            ranks.push((bv, rank.into_boxed_slice()))
-        }
-
-        ranks.into_boxed_slice()
-    }
-
-    #[inline]
-    fn get_rank(&self, hash: u64, i: usize) -> u64 {
-        let idx = hash as usize;
-        let (bv, ranks) = self.bitvecs.get(i).expect("that level doesn't exist");
-
-        // Last pre-computed rank
-        let mut rank = ranks[idx / 512];
-
-        // Add rank of intervening words
-        for j in (idx / 64) & !7..idx / 64 {
-            rank += bv.get_word(j).count_ones() as u64;
-        }
-
-        // Add rank of final word up to hash
-        let final_word = bv.get_word(idx / 64);
-        if idx % 64 > 0 {
-            rank += (final_word << (64 - (idx % 64))).count_ones() as u64;
-        }
-        rank
-    }
-
     /// Compute the hash value of `item`. This method should only be used
     /// with items known to be in construction set. Use `try_hash` if you cannot
     /// guarantee that `item` was in the construction set. If `item` was not present
@@ -318,7 +488,7 @@ impl<T: Hash + Debug> Mphf<T> {
     pub fn hash(&self, item: &T) -> u64 {
         for i in 0..self.bitvecs.len() {
             let (bv, _) = &self.bitvecs[i];
-            let hash = hashmod(i as u64, item, bv.capacity() as u64);
+            let hash = hashmod(i as u64, item, bv.capacity());
 
             if bv.contains(hash) {
                 return self.get_rank(hash, i);
@@ -334,11 +504,11 @@ impl<T: Hash + Debug> Mphf<T> {
     pub fn try_hash<Q>(&self, item: &Q) -> Option<u64>
     where
         T: Borrow<Q>,
-        Q: ?Sized + Hash,
+        Q: ?Sized + SeedableHash,
     {
         for i in 0..self.bitvecs.len() {
             let (bv, _) = &(self.bitvecs)[i];
-            let hash = hashmod(i as u64, item, bv.capacity() as u64);
+            let hash = hashmod(i as u64, item, bv.capacity());
 
             if bv.contains(hash) {
                 return Some(self.get_rank(hash, i));
@@ -350,7 +520,7 @@ impl<T: Hash + Debug> Mphf<T> {
 }
 
 #[cfg(feature = "parallel")]
-impl<T: Hash + Debug + Sync + Send> Mphf<T> {
+impl<T: SeedableHash + Debug + Sync + Send> Mphf<T> {
     /// Same as `new`, but parallelizes work on the rayon default Rayon threadpool.
     /// Configure the number of threads on that threadpool to control CPU usage.
     #[cfg(feature = "parallel")]
@@ -412,7 +582,7 @@ struct Context {
 impl Context {
     fn new(size: u64, seed: u64) -> Self {
         Self {
-            size: size as u64,
+            size,
             seed,
             a: BitVector::new(size),
             collide: BitVector::new(size),
@@ -420,14 +590,14 @@ impl Context {
     }
 
     #[cfg(feature = "parallel")]
-    fn find_collisions<T: Hash>(&self, v: &T) {
+    fn find_collisions<T: SeedableHash>(&self, v: &T) {
         let idx = hashmod(self.seed, v, self.size);
         if !self.collide.contains(idx) && !self.a.insert(idx) {
             self.collide.insert(idx);
         }
     }
 
-    fn find_collisions_sync<T: Hash>(&mut self, v: &T) {
+    fn find_collisions_sync<T: SeedableHash>(&mut self, v: &T) {
         let idx = hashmod(self.seed, v, self.size);
         if !self.collide.contains(idx) && !self.a.insert_sync(idx) {
             self.collide.insert_sync(idx);
@@ -435,7 +605,7 @@ impl Context {
     }
 
     #[cfg(feature = "parallel")]
-    fn filter<'t, T: Hash>(&self, v: &'t T) -> Option<&'t T> {
+    fn filter<'t, T: SeedableHash>(&self, v: &'t T) -> Option<&'t T> {
         let idx = hashmod(self.seed, v, self.size);
         if self.collide.contains(idx) {
             self.a.remove(idx);
@@ -446,7 +616,7 @@ impl Context {
     }
 
     #[cfg(not(feature = "parallel"))]
-    fn filter<'t, T: Hash>(&mut self, v: &'t T) -> Option<&'t T> {
+    fn filter<'t, T: SeedableHash>(&mut self, v: &'t T) -> Option<&'t T> {
         let idx = hashmod(self.seed, v, self.size);
         if self.collide.contains(idx) {
             self.a.remove(idx);
@@ -527,7 +697,10 @@ where
 }
 
 #[cfg(feature = "parallel")]
-impl<'a, T: 'a + Hash + Debug + Send + Sync> Mphf<T> {
+impl<'a, T: 'a + SeedableHash + Debug + Send + Sync> Mphf<T>
+where
+    &'a T: SeedableHash,
+{
     /// Same as to `from_chunked_iterator` but parallelizes work over `num_threads` threads.
     #[cfg(feature = "parallel")]
     pub fn from_chunked_iterator_parallel<I, N>(
@@ -563,7 +736,7 @@ impl<'a, T: 'a + Hash + Debug + Send + Sync> Mphf<T> {
         loop {
             if max_iters.is_some() && iter > max_iters.unwrap() {
                 error!("ran out of key space. items: {:?}", global.done_keys.len());
-                panic!("counldn't find unique hashes");
+                panic!("couldn't find unique hashes");
             }
 
             let keys_remaining = if iter == 0 {
@@ -695,7 +868,7 @@ mod tests {
     /// Check that a Minimal perfect hash function (MPHF) is generated for the set xs
     fn check_mphf<T>(xs: HashSet<T>) -> bool
     where
-        T: Sync + Hash + PartialEq + Eq + Debug + Send,
+        T: Sync + SeedableHash + PartialEq + Eq + Debug + Send,
     {
         let xsv: Vec<T> = xs.into_iter().collect();
 
@@ -706,7 +879,7 @@ mod tests {
     /// Check that a Minimal perfect hash function (MPHF) is generated for the set xs
     fn check_mphf_serial<T>(xsv: &[T]) -> bool
     where
-        T: Hash + PartialEq + Eq + Debug,
+        T: SeedableHash + PartialEq + Eq + Debug,
     {
         // Generate the MPHF
         let phf = Mphf::new(1.7, xsv);
@@ -725,7 +898,7 @@ mod tests {
     #[cfg(feature = "parallel")]
     fn check_mphf_parallel<T>(xsv: &[T]) -> bool
     where
-        T: Sync + Hash + PartialEq + Eq + Debug + Send,
+        T: Sync + SeedableHash + PartialEq + Eq + Debug + Send,
     {
         // Generate the MPHF
         let phf = Mphf::new_parallel(1.7, xsv, None);
@@ -743,14 +916,14 @@ mod tests {
     #[cfg(not(feature = "parallel"))]
     fn check_mphf_parallel<T>(_xsv: &[T]) -> bool
     where
-        T: Hash + PartialEq + Eq + Debug,
+        T: SeedableHash + PartialEq + Eq + Debug,
     {
         true
     }
 
     fn check_chunked_mphf<T>(values: Vec<Vec<T>>, total: u64) -> bool
     where
-        T: Sync + Hash + PartialEq + Eq + Debug + Send,
+        T: Sync + SeedableHash + PartialEq + Eq + Debug + Send,
     {
         let phf = Mphf::from_chunked_iterator(1.7, &values, total);
 
@@ -770,7 +943,7 @@ mod tests {
     #[cfg(feature = "parallel")]
     fn check_chunked_mphf_parallel<T>(values: Vec<Vec<T>>, total: u64) -> bool
     where
-        T: Sync + Hash + PartialEq + Eq + Debug + Send,
+        T: Sync + SeedableHash + PartialEq + Eq + Debug + Send,
     {
         let phf = Mphf::from_chunked_iterator_parallel(1.7, &values, None, total, 2);
 
@@ -876,5 +1049,28 @@ mod tests {
     fn from_ints_serial() {
         let items = (0..1000000).map(|x| x * 2);
         assert!(check_mphf(HashSet::from_iter(items)));
+    }
+
+    #[test]
+    fn externally_hashed() {
+        let total = 1000000;
+        // User gets to pick the hash function.
+        let entries = (0..total)
+            .map(|x| ExternallyHashed(wyhash::wyrng(&mut (x * 2))))
+            .collect::<Vec<ExternallyHashed>>();
+        let phf = Mphf::new(1.7, &entries);
+
+        let mut hashes = entries.iter().map(|eh| phf.hash(eh)).collect::<Vec<u64>>();
+        hashes.sort_unstable();
+
+        let gt = (0..total as u64).collect::<Vec<u64>>();
+        assert_eq!(hashes, gt);
+
+        // Hand-picked a value that fails to hash since it's not in the original set that it's built from.
+        // It's not ideal that this assertion is sensitive to the implementation details internal to Mphf.
+        assert_eq!(
+            phf.try_hash(&ExternallyHashed(wyhash::wyrng(&mut 1000129))),
+            None
+        );
     }
 }

--- a/src/par_iter.rs
+++ b/src/par_iter.rs
@@ -1,12 +1,11 @@
-use std::hash::Hash;
-
 use crate::hashmap::BoomHashMap;
+use crate::SeedableHash;
 use rayon::iter::plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 impl<'data, K, V> IntoParallelIterator for &'data BoomHashMap<K, V>
 where
-    K: Hash + Sync + 'data,
+    K: SeedableHash + Sync + 'data,
     V: Sync + 'data,
 {
     type Item = (&'data K, &'data V);


### PR DESCRIPTION
Expose a way to retrieve the underlying contents of the Mphf as a series of scattered slices which can then be written to disk efficiently.

Create a new MphfRef struct that can be used to take in aligned scattered slices to cheaply construct a queriable interface without copying the underlying data. This is useful for 0-copy construction when accessing the underlying disk blocks as mmap.

This is just 1 commit that builds off https://github.com/10XGenomics/rust-boomphf/pull/40/