### PR TITLE
Optional implementation of DeepSizeOf for BoomHashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rayon = { version=">=1.0", optional = true }
 crossbeam-utils = { version=">=0.7.2, <0.9", optional = true }
 wyhash = ">=0.3, <=0.5"
 log = "0.4.*"
+deepsize = { version="0.2.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0.2"

--- a/src/bitvector.rs
+++ b/src/bitvector.rs
@@ -30,6 +30,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(feature = "serde")]
 use serde::{self, Deserialize, Serialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 
 #[cfg(feature = "parallel")]
 type Word = AtomicU64;
@@ -381,6 +383,13 @@ impl BitVector {
             idx: 0,
             size: self.bits,
         }
+    }
+}
+
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for BitVector {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.bits.deep_size_of_children(context) + self.vector.deep_size_of_children(context)
     }
 }
 

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -3,6 +3,9 @@
 #[cfg(feature = "serde")]
 use serde::{self, Deserialize, Serialize};
 
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
+
 use crate::Mphf;
 use std::borrow::Borrow;
 use std::fmt::Debug;
@@ -128,6 +131,19 @@ where
             hash: self,
             index: 0,
         }
+    }
+}
+
+#[cfg(feature = "deepsize")]
+impl<K, D> DeepSizeOf for BoomHashMap<K, D>
+where
+    K: Hash + Debug + PartialEq + DeepSizeOf,
+    D: Debug + DeepSizeOf,
+{
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.mphf.deep_size_of_children(context)
+            + self.keys.deep_size_of_children(context)
+            + self.values.deep_size_of_children(context)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "serde")]
 use serde::{self, Deserialize, Serialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 
 #[inline]
 fn fold(v: u64) -> u32 {
@@ -405,6 +407,13 @@ impl<T: Hash + Debug + Sync + Send> Mphf<T> {
             bitvecs: Self::compute_ranks(bitvecs),
             phantom: PhantomData,
         }
+    }
+}
+
+#[cfg(feature = "deepsize")]
+impl<T> DeepSizeOf for Mphf<T> {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.bitvecs.deep_size_of_children(context) + self.phantom.deep_size_of_children(context)
     }
 }
 


### PR DESCRIPTION
Allow consumers to get the total allocated size of a BoomHashMap